### PR TITLE
Corrected navbar stacking on small viewport, changed dropdown placeholders, delete image from tasks

### DIFF
--- a/Views/Shared/_NavBarPartial.cshtml
+++ b/Views/Shared/_NavBarPartial.cshtml
@@ -2,7 +2,7 @@
     <div class="bs-component">
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
             <a class="navbar-brand" href="@Url.Action("Index", "Home")">²BᵉDᵒⁿᵉ</a>
-            <div class="col-lg-1 col-sm-4 text-center"><a class="nav-item btn-primary btn-sm btn-block" href="@Url.Action("New", "Tasks")">New Task</a></div>
+            <div class=" text-center"><a class="nav-item btn-primary btn-sm " href="@Url.Action("New", "Tasks")">New Task</a></div>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor03" aria-controls="navbarColor03" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -22,13 +22,13 @@
                     </li>
 
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Dropdown</a>
+                        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">Account Name</a>
                         <div class="dropdown-menu">
-                            <a class="dropdown-item" href="#">Action</a>
+                            <a class="dropdown-item" href="#">Profile</a>
                             <a class="dropdown-item" href="#">Another action</a>
-                            <a class="dropdown-item" href="#">Something else here</a>
+                            <a class="dropdown-item" href="#">Settings</a>
                             <div class="dropdown-divider"></div>
-                            <a class="dropdown-item" href="#">Separated link</a>
+                            <a class="dropdown-item text-danger" href="#">Logout</a>
                         </div>
                     </li>
                 </ul>

--- a/Views/Tasks/Doing.cshtml
+++ b/Views/Tasks/Doing.cshtml
@@ -3,34 +3,38 @@
     ViewData["Title"] = "Doing";
 }
 @{
-    foreach (var task in Model)
-    {
-        <div class="container-fluid">
-            <div class="bs-component">
-                <div class="card mb-3">
-                    <h3 class="card-header" >Task</h3>
-                    <div class="card-footer text-muted">
-                        Created On @task.CreatedDate.ToShortDateString()
-                    </div>
-                    <div class="card-body">
-                        <h5 class="card-title">@task.Title</h5>
-                        <h6 class="card-subtitle text-muted">Some extra shit</h6>
-                    </div>
-                    <div class="card-body">
-                        <p class="card-text">@task.Details</p>
-                    </div>
-                    <ul class="list-group list-group-flush">
-                        <li class="list-group-item"><p class="font-italic">Qualifers</p> <p class="font-weight-bold">@task.Qualifiers.Qualifiers</p></li>
-                        <li class="list-group-item"><p class="font-italic">Outcomes</p> <p class="font-weight-bold">@task.Outcomes.Outcomes</p></li>
-                    </ul>
-                    <div class="card-body">
-                        @Html.ActionLink("Edit", "Edit", new {id = task.Id, @class = "btn-primary btn-sm" }, null)
-                    </div>
-                    <div class="card-footer text-muted">
-                        Deadline @task.EndDate.ToShortDateString()
+    <section class="basic-grid">
+        @foreach (var task in Model)
+        {
+
+            <div class="card">
+                <div class="bs-component">
+                    <div class="card mb-3">
+                        <h3 class="card-header">Task</h3>
+                        <div class="card-footer text-muted">
+                            Created On @task.CreatedDate.ToShortDateString()
+                        </div>
+                        <div class="card-body">
+                            <h5 class="card-title">@task.Title</h5>
+                            <h6 class="card-subtitle text-muted">Some extra shit</h6>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text">@task.Details.Details</p>
+                        </div>
+                        <ul class="list-group list-group-flush">
+                            <li class="list-group-item"><p class="font-italic">Qualifers</p> <p class="font-weight-bold">@task.Qualifiers.Qualifiers</p></li>
+                            <li class="list-group-item"><p class="font-italic">Outcomes</p> <p class="font-weight-bold">@task.Outcomes.Outcomes</p></li>
+                        </ul>
+                        <div class="card-body">
+                            @Html.ActionLink("Edit", "Edit", new { id = task.Id, @class = "btn-primary btn-sm" }, null)
+                        </div>
+                        <div class="card-footer text-muted">
+                            Deadline @task.EndDate.ToShortDateString()
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    }
+
+        }
+    </section>
 }

--- a/Views/Tasks/Doing.cshtml
+++ b/Views/Tasks/Doing.cshtml
@@ -11,7 +11,7 @@
         <div class="container-fluid">
             <div class="bs-component">
                 <div class="card mb-3">
-                    <h3 class="card-header">Task</h3>
+                    <h3 class="card-header" >Task</h3>
                     <div class="card-footer text-muted">
                         Created On @task.CreatedDate.ToShortDateString()
                     </div>
@@ -19,10 +19,7 @@
                         <h5 class="card-title">@task.Title</h5>
                         <h6 class="card-subtitle text-muted">Some extra shit</h6>
                     </div>
-                    <svg xmlns="http://www.w3.org/2000/svg" class="d-block user-select-none" width="100%" height="200" aria-label="Placeholder: Would Images Be Useful?" focusable="false" role="img" preserveAspectRatio="xMidYMid slice" viewBox="0 0 318 180" style="font-size:1.125rem;text-anchor:middle">
-                        <rect width="100%" height="100%" fill="#868e96" data-darkreader-inline-fill="" style="--darkreader-inline-fill:#585f63;"></rect>
-                        <text x="50%" y="50%" fill="#dee2e6" dy=".3em" data-darkreader-inline-fill="" style="--darkreader-inline-fill:#d6d2cd;">Image cap</text>
-                    </svg>
+                    
                     <div class="card-body">
                         <p class="card-text">@task.Details</p>
                     </div>


### PR DESCRIPTION
#Description
- Fix an issue where on view ports smaller than 720px width nav-bar elements would stack in a gross way.
- updated dropdown items placeholder names for future work
- Deleted images from tasks

#Scope:

`_NavBarPartial.cshtml`
  - deleted boostrap classes causing size issue
  - adjust new task button style
  - changed placeholder values for later work

`Doing.cshtml`
  - Deleted image cap placeholder
