### PR TITLE
Enviroment variable configuration for runtime and app info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ FROM mcr.microsoft.com/dotnet/aspnet:5.0 as base
 WORKDIR /app
 COPY --from=build /app ./
 
-ENTRYPOINT [ "dotnet", "ToDoList.dll", "--environment=Development" ]
+ENTRYPOINT [ "dotnet", "ToDoList.dll", "--environment=Production" ]
 

--- a/Kubernetes/dev.yaml
+++ b/Kubernetes/dev.yaml
@@ -21,8 +21,8 @@ spec:
           ports:
               - containerPort: 80
           env:
-            - name: HOST_ENVIRONMENT
-              value: DEVELOPMENT
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Production
             - name: FACEBOOK_APPID
               valueFrom:
                 secretKeyRef:

--- a/Kubernetes/dev.yaml
+++ b/Kubernetes/dev.yaml
@@ -21,6 +21,18 @@ spec:
           ports:
               - containerPort: 80
           env:
+            - name: HOST_ENVIRONMENT
+              value: DEVELOPMENT
+            - name: FACEBOOK_APPID
+              valueFrom:
+                secretKeyRef:
+                  name: dev-tobedone
+                  key: FACEBOOK_APPID
+            - name: FACEBOOK_APPSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dev-tobedone
+                  key: FACEBOOK_APPSECRET  
             - name: PUID
               value: "1000"
             - name: PGID

--- a/Startup.cs
+++ b/Startup.cs
@@ -24,6 +24,7 @@ namespace ToDoList
         }
 
         public IConfiguration Configuration { get; }
+        public Microsoft.AspNetCore.Hosting.IWebHostEnvironment HostingEnvironment { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -42,10 +43,19 @@ namespace ToDoList
             services.AddAuthentication()
                 .AddFacebook(facebookOptions =>
                 {
-                    facebookOptions.AppId = Configuration["Authentication:Facebook:AppId"];
-                    facebookOptions.AppSecret = Configuration["Authentication:Facebook:AppSecret"];
+                    if (HostingEnvironment.IsDevelopment())
+                    {
+                        facebookOptions.AppId = Configuration["Authentication:Facebook:AppId"];
+                        facebookOptions.AppSecret = Configuration["Authentication:Facebook:AppSecret"];
+                    }
+                    else
+                    {
+                        //https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable?view=net-5.0#definition
+                        facebookOptions.AppId = Environment.GetEnvironmentVariable("Facebook_AppId");
+                        facebookOptions.AppSecret = Environment.GetEnvironmentVariable("Facebook_AppSecret");
+                    }
                     facebookOptions.AccessDeniedPath = "/AccessDeniedPathInfo";
-                }); 
+                });
             services.AddControllersWithViews();
         }
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -24,10 +24,9 @@ namespace ToDoList
         }
 
         public IConfiguration Configuration { get; }
-        public Microsoft.AspNetCore.Hosting.IWebHostEnvironment HostingEnvironment { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+        public void ConfigureServices(IServiceCollection services, IWebHostEnvironment env)
         {
             services.AddAutoMapper(typeof(Startup));
             services.AddDbContext<SQLiteDBContext>(options =>
@@ -43,7 +42,7 @@ namespace ToDoList
             services.AddAuthentication()
                 .AddFacebook(facebookOptions =>
                 {
-                    if (HostingEnvironment.IsDevelopment())
+                    if (env.IsDevelopment())
                     {
                         facebookOptions.AppId = Configuration["Authentication:Facebook:AppId"];
                         facebookOptions.AppSecret = Configuration["Authentication:Facebook:AppSecret"];

--- a/Startup.cs
+++ b/Startup.cs
@@ -51,8 +51,8 @@ namespace ToDoList
                     else
                     {
                         //https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable?view=net-5.0#definition
-                        facebookOptions.AppId = Environment.GetEnvironmentVariable("Facebook_AppId");
-                        facebookOptions.AppSecret = Environment.GetEnvironmentVariable("Facebook_AppSecret");
+                        facebookOptions.AppId = Environment.GetEnvironmentVariable("FACEBOOK_APPID");
+                        facebookOptions.AppSecret = Environment.GetEnvironmentVariable("FACEBOOK_APPSECRET");
                     }
                     facebookOptions.AccessDeniedPath = "/AccessDeniedPathInfo";
                 });

--- a/Startup.cs
+++ b/Startup.cs
@@ -42,8 +42,8 @@ namespace ToDoList
                 .AddDefaultUI()
                 .AddDefaultTokenProviders();
             Console.WriteLine("Hosting Enviroment is " + HostingEnvironment.EnvironmentName);
-            Console.WriteLine(Environment.GetEnvironmentVariable("FACEBOOK_APPID"));
-            Console.WriteLine(Environment.GetEnvironmentVariable("FACEBOOK_APPSECRET"));
+            Console.WriteLine("AppId is null or empty? ", string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FACEBOOK_APPID")));
+            Console.WriteLine("AppSecret is null or empty? ", string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FACEBOOK_APPSECRET")));
             services.AddAuthentication()
                 .AddFacebook(facebookOptions =>
                 {

--- a/Startup.cs
+++ b/Startup.cs
@@ -41,6 +41,9 @@ namespace ToDoList
                 .AddEntityFrameworkStores<SQLiteDBContext>()
                 .AddDefaultUI()
                 .AddDefaultTokenProviders();
+            Console.WriteLine("Hosting Enviroment is " + HostingEnvironment.EnvironmentName);
+            Console.WriteLine(Environment.GetEnvironmentVariable("FACEBOOK_APPID"));
+            Console.WriteLine(Environment.GetEnvironmentVariable("FACEBOOK_APPSECRET"));
             services.AddAuthentication()
                 .AddFacebook(facebookOptions =>
                 {
@@ -54,10 +57,12 @@ namespace ToDoList
                         //https://docs.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable?view=net-5.0#definition
                         facebookOptions.AppId = Environment.GetEnvironmentVariable("FACEBOOK_APPID");
                         facebookOptions.AppSecret = Environment.GetEnvironmentVariable("FACEBOOK_APPSECRET");
+                        
                     }
                     facebookOptions.AccessDeniedPath = "/AccessDeniedPathInfo";
                 });
             services.AddControllersWithViews();
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Startup.cs
+++ b/Startup.cs
@@ -18,15 +18,17 @@ namespace ToDoList
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
+        public Startup(IConfiguration configuration, IHostEnvironment hostingEnvironment)
         {
             Configuration = configuration;
+            HostingEnvironment = hostingEnvironment;
         }
 
         public IConfiguration Configuration { get; }
+        public IHostEnvironment HostingEnvironment { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services, IWebHostEnvironment env)
+        public void ConfigureServices(IServiceCollection services)
         {
             services.AddAutoMapper(typeof(Startup));
             services.AddDbContext<SQLiteDBContext>(options =>
@@ -42,7 +44,7 @@ namespace ToDoList
             services.AddAuthentication()
                 .AddFacebook(facebookOptions =>
                 {
-                    if (env.IsDevelopment())
+                    if (HostingEnvironment.IsDevelopment())
                     {
                         facebookOptions.AppId = Configuration["Authentication:Facebook:AppId"];
                         facebookOptions.AppSecret = Configuration["Authentication:Facebook:AppSecret"];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
           source: .\DB
           target: /ToDoList/DB/
       environment:
-        - FACEBOOK_APPID=306162131078600
-        - FACEBOOK_APPSECRET=872daecc1b3b0cba322f38029450e17e
+        - FACEBOOK_APPID=
+        - FACEBOOK_APPSECRET=
         - ASPNETCORE_ENVIRONMENT=Production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.8"
 
 services:
     web:
+      image: leolazz/2bdone:latest
       build: .
       ports: 
         - "5000:80"
@@ -10,5 +11,7 @@ services:
           source: .\DB
           target: /ToDoList/DB/
       environment:
-        - Development
+        - FACEBOOK_APPID=306162131078600
+        - FACEBOOK_APPSECRET=872daecc1b3b0cba322f38029450e17e
+        - ASPNETCORE_ENVIRONMENT=Production
 


### PR DESCRIPTION
# Description:
Resolve app secret and app id for facebook authentication in production environment.

`Startup.cs`
 - Added a check for developer vs production environment that will provide authentication with app info either from a dotnet user secret or an environment variable.
 - Configured to print the development environment variable and whether or not the app id and secret is null/empty to the console on startup for easier debugging.
 
`Dockerfile`
 - Changed entry point to production

`dev.yaml`
 - added environment variables for facebook app id and secret
 - corrected syntax for asp runtime environment variable

`docker-compose.yaml`
 - corrected syntax for asp runtime environment variable
